### PR TITLE
Fixed initial downElem trigger click

### DIFF
--- a/assets/js/jquery.threesixty.js
+++ b/assets/js/jquery.threesixty.js
@@ -299,7 +299,9 @@ var scope,
 
     ThreeSixty.prototype.onMouseUp = function(e) {
         isMouseDown = false;
-        $downElem.trigger('up');
+        if (typeof $downElem !== 'object') {
+            $downElem.trigger('up');
+        }
     };
 
     /**


### PR DESCRIPTION
When the script is fired, there’s currently a bug where clicking
anywhere will cause an TypeError, as $downElem is an object. Added a
check to see if it’s an object or not.
